### PR TITLE
35 add evaluation scripts and launch for the environments

### DIFF
--- a/src/environments/environments/CarGoalEnvironment.py
+++ b/src/environments/environments/CarGoalEnvironment.py
@@ -52,13 +52,13 @@ class CarGoalEnvironment(Node):
         # Pub/Sub ----------------------------------------------------
         self.cmd_vel_pub = self.create_publisher(
                 Twist,
-                f'/model/{self.NAME}/cmd_vel',
+                f'/{self.NAME}/cmd_vel',
                 10
             )
 
         self.odom_sub = self.create_subscription(
             Odometry,
-            f'/model/{self.NAME}/odometry',
+            f'/{self.NAME}/odometry',
             self.odom_callback,
             10
             )

--- a/src/reinforcement_learning/config/car_goal.yaml
+++ b/src/reinforcement_learning/config/car_goal.yaml
@@ -1,3 +1,7 @@
+meta:
+  ros__parameters:
+    mode: evaluation # training
+
 car_goal_training:
   ros__parameters:
     max_steps_exploration: 5000
@@ -12,3 +16,9 @@ car_goal_training:
     # max_steps: 100
     # step_length: 0.25
     # seed: 123
+
+car_goal_testing:
+  ros__parameters:
+    max_steps_evaluation: 1000000
+    actor_path: models/cargoal_training-0_actor.pht
+    critic_path: models/cargoal_training-0_critic.pht

--- a/src/reinforcement_learning/config/car_wall.yaml
+++ b/src/reinforcement_learning/config/car_wall.yaml
@@ -1,3 +1,7 @@
+meta:
+  ros__parameters:
+    mode: training
+
 car_wall_training:
   ros__parameters:
     max_steps_exploration: 5000
@@ -12,3 +16,9 @@ car_wall_training:
     # max_steps: 100
     # step_length: 0.25
     # seed: 123
+
+car_wall_testing:
+  ros__parameters:
+    max_steps_evaluation: 1000000
+    actor_path: models/carwall_training-13-06-2023-23:24:07_0_actor.pht
+    critic_path: models/carwall_training-13-06-2023-23:24:07_0_critic.pht

--- a/src/reinforcement_learning/config/car_wall.yaml
+++ b/src/reinforcement_learning/config/car_wall.yaml
@@ -1,6 +1,6 @@
 meta:
   ros__parameters:
-    mode: training
+    mode: evaluation # training
 
 car_wall_training:
   ros__parameters:

--- a/src/reinforcement_learning/config/config.yaml
+++ b/src/reinforcement_learning/config/config.yaml
@@ -1,0 +1,1 @@
+mode: training

--- a/src/reinforcement_learning/launch/car_goal.launch.py
+++ b/src/reinforcement_learning/launch/car_goal.launch.py
@@ -4,6 +4,7 @@ from launch_ros.actions import Node
 from launch import LaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
+import yaml
 
 def generate_launch_description(): #TODO: include the train launch file here
     pkg_f1tenth_description = get_package_share_directory('f1tenth_description')
@@ -25,20 +26,23 @@ def generate_launch_description(): #TODO: include the train launch file here
             'car_name': 'f1tenth',
         }.items() #TODO: this doesn't do anything
     )
-
-    config = os.path.join(
+    
+    config_path = os.path.join(
         get_package_share_directory('reinforcement_learning'),
         'car_goal.yaml'
     )
 
+    config = yaml.load(open(config_path))
+    mode = config['meta']['ros__parameters']['mode']
+
     # Launch the Environment
     main = Node(
             package='reinforcement_learning',
-            executable='car_goal_training',
+            executable='car_goal_training' if mode != 'evaluation' else 'car_goal_testing',
             parameters=[
-                config
+                config_path
             ],
-            name='car_goal_training',
+            name='car_goal_training' if mode != 'evaluation' else 'car_goal_testing',
             output='screen',
             emulate_tty=True, # Allows python print to show
     )

--- a/src/reinforcement_learning/launch/car_goal.launch.py
+++ b/src/reinforcement_learning/launch/car_goal.launch.py
@@ -21,10 +21,11 @@ def generate_launch_description(): #TODO: include the train launch file here
     
     f1tenth = IncludeLaunchDescription(
         launch_description_source=PythonLaunchDescriptionSource(
-            os.path.join(pkg_f1tenth_bringup, 'f1tenth_simulation.launch.py')),
+            os.path.join(pkg_f1tenth_bringup, 'simulation_bringup.launch.py')),
         launch_arguments={
-            'car_name': 'f1tenth',
-        }.items() #TODO: this doesn't do anything
+            'name': 'f1tenth',
+            'world': 'empty',
+        }.items()
     )
     
     config_path = os.path.join(

--- a/src/reinforcement_learning/launch/car_wall.launch.py
+++ b/src/reinforcement_learning/launch/car_wall.launch.py
@@ -4,6 +4,7 @@ from launch_ros.actions import Node, SetParameter
 from launch import LaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
+import yaml
 
 def generate_launch_description():
     pkg_f1tenth_description = get_package_share_directory('f1tenth_description')
@@ -17,7 +18,7 @@ def generate_launch_description():
             'car_name': 'f1tenth',
         }.items() #TODO: this doesn't do anything
     )
-    
+
     f1tenth = IncludeLaunchDescription(
         launch_description_source=PythonLaunchDescriptionSource(
             os.path.join(pkg_f1tenth_bringup, 'simulation_bringup.launch.py')),
@@ -27,19 +28,24 @@ def generate_launch_description():
         }.items()
     )
 
-    config = os.path.join(
+    config_path = os.path.join(
         get_package_share_directory('reinforcement_learning'),
         'car_wall.yaml'
     )
 
+    
+    
+    config = yaml.load(open(config_path))
+    mode = config['meta']['ros__parameters']['mode']
+
     # Launch the Environment
     main = Node(
             package='reinforcement_learning',
-            executable='car_wall_training',
+            executable='car_wall_training' if mode != 'evaluation' else 'car_wall_testing',
             parameters=[
-                config
+                config_path
             ],
-            name='car_wall_training',
+            name='car_wall_training' if mode != 'evaluation' else 'car_wall_testing',
             output='screen',
             emulate_tty=True, # Allows python print to show
     )

--- a/src/reinforcement_learning/reinforcement_learning/car_goal_testing.py
+++ b/src/reinforcement_learning/reinforcement_learning/car_goal_testing.py
@@ -6,26 +6,53 @@ from ament_index_python import get_package_share_directory
 import time
 import torch
 import random
-from cares_reinforcement_learning.algorithm import TD3
-from cares_reinforcement_learning.util import MemoryBuffer, helpers as hlp
+from cares_reinforcement_learning.algorithm.policy import TD3
+from cares_reinforcement_learning.memory import MemoryBuffer
+from cares_reinforcement_learning.util import helpers as hlp
 from cares_reinforcement_learning.util.Plot import Plot
 from cares_reinforcement_learning.networks.TD3 import Actor, Critic
 
 import numpy as np
 
-MAX_TESTING_STEPS = 1_000_000
 
-GAMMA = 0.95
-TAU = 0.005
-G = 10
+rclpy.init()
 
-BATCH_SIZE = 32
-BUFFER_SIZE = 1_000_000
+param_node = rclpy.create_node('params')
+param_node.declare_parameters(
+    '',
+    [
+        ('max_steps_evaluation', 1_000_000),
+        ('max_steps', 100),
+        ('step_length', 0.25),
+        ('actor_path', ''),
+        ('critic_path', '')
+    ]
+)
 
-SEED = 123
+params = param_node.get_parameters([
+    'max_steps_evaluation',
+    'max_steps',
+    'step_length',
+    'actor_path',
+    'critic_path',
+    ])
 
-ACTOR_LR = 1e-4
-CRITIC_LR = 1e-3
+MAX_STEPS_EVALUATION, \
+MAX_STEPS,\
+STEP_LENGTH,\
+ACTOR_PATH,\
+CRITIC_PATH = [param.value for param in params]
+
+print(
+    f'Evaluation Steps: {MAX_STEPS_EVALUATION}\n',
+    f'Steps per Episode: {MAX_STEPS}\n',
+    f'Step Length: {STEP_LENGTH}\n',
+    f'Critic Path: {CRITIC_PATH}\n',
+    f'Actor Path: {ACTOR_PATH}'
+)
+
+if ACTOR_PATH is '' or CRITIC_PATH is '':
+    raise Exception('Actor or Critic path not provided')
 
 MAX_ACTIONS = np.asarray([3, 1])
 MIN_ACTIONS = np.asarray([0, -1])
@@ -36,27 +63,31 @@ ACTION_NUM = 2
 DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 def main():
-    rclpy.init()
     
     # Share Directories
 
     time.sleep(3)
-    env = CarGoalEnvironment('f1tenth', step_length=0.25, max_steps=100)
-    # env = CarWallEnvironment('f1tenth', step_length=0.25)
+    env = CarGoalEnvironment('f1tenth', step_length=STEP_LENGTH, max_steps=MAX_STEPS)
     
-    actor = Actor(observation_size=OBSERVATION_SIZE, num_actions=ACTION_NUM, learning_rate=ACTOR_LR)
-    critic = Critic(observation_size=OBSERVATION_SIZE, num_actions=ACTION_NUM, learning_rate=CRITIC_LR)
+    actor = Actor(observation_size=OBSERVATION_SIZE, num_actions=ACTION_NUM, learning_rate=0.001)
+    critic = Critic(observation_size=OBSERVATION_SIZE, num_actions=ACTION_NUM, learning_rate=0.001)
+
+    print('Reading saved models into actor and critic')
+    actor.load_state_dict(torch.load(ACTOR_PATH))
+    critic.load_state_dict(torch.load(CRITIC_PATH))
+
+    print('Successfully Loaded models')
 
     agent = TD3(
         actor_network=actor,
         critic_network=critic,
-        gamma=GAMMA,
-        tau=TAU,
+        gamma=0.001,
+        tau=0.001,
         action_num=ACTION_NUM,
         device=DEVICE
     )
     
-    agent.load_models('training_logs/12-may-training-cargoal-success/', '12-may-cargoal-step-675000')
+
     test(env=env, agent=agent)
 
 def test(env, agent: TD3):
@@ -65,7 +96,7 @@ def test(env, agent: TD3):
     episode_reward = 0
     episode_num = 0
     
-    for total_step_counter in range(int(MAX_TESTING_STEPS)):
+    for total_step_counter in range(int(MAX_STEPS_EVALUATION)):
         episode_timesteps += 1
 
         action = agent.select_action_from_policy(state)

--- a/src/reinforcement_learning/reinforcement_learning/car_wall_testing.py
+++ b/src/reinforcement_learning/reinforcement_learning/car_wall_testing.py
@@ -72,7 +72,7 @@ def main():
     actor.load_state_dict(torch.load(ACTOR_PATH))
     critic.load_state_dict(torch.load(CRITIC_PATH))
 
-    print('SuccessfullylLoaded models')
+    print('Successfully Loaded models')
     
     agent = TD3(
         actor_network=actor,

--- a/src/reinforcement_learning/reinforcement_learning/car_wall_testing.py
+++ b/src/reinforcement_learning/reinforcement_learning/car_wall_testing.py
@@ -1,0 +1,117 @@
+from environments.CarGoalEnvironment import CarGoalEnvironment
+from environments.CarWallEnvironment import CarWallEnvironment
+import rclpy
+from ament_index_python import get_package_share_directory
+import time
+import torch
+import random
+from cares_reinforcement_learning.algorithm.policy import TD3
+from cares_reinforcement_learning.util import helpers as hlp
+from cares_reinforcement_learning.networks.TD3 import Actor, Critic
+
+import numpy as np
+
+rclpy.init()
+
+param_node = rclpy.create_node('params')
+param_node.declare_parameters(
+    '',
+    [
+        ('max_steps_evaluation', 1_000_000),
+        ('max_steps', 100),
+        ('step_length', 0.25),
+        ('actor_path', ''),
+        ('critic_path', '')
+    ]
+)
+
+params = param_node.get_parameters([
+    'max_steps_evaluation',
+    'max_steps',
+    'step_length',
+    'actor_path',
+    'critic_path',
+    ])
+
+MAX_STEPS_EVALUATION, \
+MAX_STEPS,\
+STEP_LENGTH,\
+ACTOR_PATH,\
+CRITIC_PATH = [param.value for param in params]
+
+print(
+    f'Evaluation Steps: {MAX_STEPS_EVALUATION}\n',
+    f'Steps per Episode: {MAX_STEPS}\n',
+    f'Step Length: {STEP_LENGTH}\n',
+    f'Critic Path: {CRITIC_PATH}\n',
+    f'Actor Path: {ACTOR_PATH}'
+)
+
+if ACTOR_PATH is '' or CRITIC_PATH is '':
+    raise Exception('Actor or Critic path not provided')
+
+
+MAX_ACTIONS = np.asarray([3, 1])
+MIN_ACTIONS = np.asarray([0, -1])
+
+OBSERVATION_SIZE = 8 + 10 + 2 # Car position + Lidar rays + goal position
+ACTION_NUM = 2
+
+DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+def main():
+    # Share Directories
+
+    time.sleep(3)
+    env = CarWallEnvironment('f1tenth', step_length=STEP_LENGTH, max_steps=MAX_STEPS)
+    
+    actor = Actor(observation_size=OBSERVATION_SIZE, num_actions=ACTION_NUM, learning_rate=0.1)
+    critic = Critic(observation_size=OBSERVATION_SIZE, num_actions=ACTION_NUM, learning_rate=0.1)
+
+    print('Reading saved models into actor and critic')
+    actor.load_state_dict(torch.load(ACTOR_PATH))
+    critic.load_state_dict(torch.load(CRITIC_PATH))
+
+    print('SuccessfullylLoaded models')
+    
+    agent = TD3(
+        actor_network=actor,
+        critic_network=critic,
+        gamma=0.999,
+        tau=0.002,
+        action_num=ACTION_NUM,
+        device=DEVICE
+    )
+
+    test(env=env, agent=agent)
+
+def test(env, agent: TD3):
+    state, _ = env.reset()    
+    episode_timesteps = 0
+    episode_reward = 0
+    episode_num = 0
+
+    print('Beginning Evaluation')
+
+    for total_step_counter in range(int(MAX_STEPS_EVALUATION)):
+        episode_timesteps += 1
+
+        action = agent.select_action_from_policy(state)
+        action_env = hlp.denormalize(action, MAX_ACTIONS, MIN_ACTIONS)
+
+        next_state, reward, done, truncated, info = env.step(action_env)
+
+        state = next_state
+        episode_reward += reward
+
+        if done or truncated:
+            print(f"Total T:{total_step_counter+1} Episode {episode_num+1} was completed with {episode_timesteps} steps taken and a Reward= {episode_reward:.3f}")
+
+            # Reset environment
+            state, _ = env.reset()
+            episode_reward    = 0
+            episode_timesteps = 0
+            episode_num += 1
+
+if __name__ == '__main__':
+    main()

--- a/src/reinforcement_learning/reinforcement_learning/car_wall_training.py
+++ b/src/reinforcement_learning/reinforcement_learning/car_wall_training.py
@@ -8,7 +8,7 @@ import random
 from cares_reinforcement_learning.algorithm.policy import TD3
 from cares_reinforcement_learning.util import helpers as hlp
 from cares_reinforcement_learning.memory import MemoryBuffer
-from cares_reinforcement_learning.util.Plot import Plot
+# from cares_reinforcement_learning.util.Plot import Plot
 from .DataManager import DataManager
 from cares_reinforcement_learning.networks.TD3 import Actor, Critic
 from datetime import datetime

--- a/src/reinforcement_learning/setup.py
+++ b/src/reinforcement_learning/setup.py
@@ -26,7 +26,8 @@ setup(
         'console_scripts': [
             'car_goal_training = reinforcement_learning.car_goal_training:main',
             'car_goal_testing= reinforcement_learning.car_goal_testing:main',
-            'car_wall_training = reinforcement_learning.car_wall_training:main'
+            'car_wall_training = reinforcement_learning.car_wall_training:main',
+            'car_wall_testing = reinforcement_learning.car_wall_testing:main'
         ],
     },
 )


### PR DESCRIPTION
Add evaluation scripts for the CarGoal and CarWall Environments:

These can be controlled via the _environment_.yaml (eg. car_wall.yaml):
An example yaml is below:
```
meta:
  ros__parameters:
    mode: evaluation # training

car_wall_training:
  ros__parameters:
    max_steps_exploration: 5000
    max_steps_training: 1000000
    # gamma: 0.95
    # tau: 0.005
    # g: 5
    # batch_size: 32
    # buffer_size: 1000000
    # actor_lr: 0.0001
    # critic_lr: 0.001
    # max_steps: 100
    # step_length: 0.25
    # seed: 123

car_wall_testing:
  ros__parameters:
    max_steps_evaluation: 1000000
    actor_path: models/carwall_training-13-06-2023-23:24:07_0_actor.pht
    critic_path: models/carwall_training-13-06-2023-23:24:07_0_critic.pht
```
Evaluation mode will run the car_wall_testing and training will run the training one