### PR TITLE
44 one training loop substitute the environments

### DIFF
--- a/src/environments/environments/CarBlockEnvironment.py
+++ b/src/environments/environments/CarBlockEnvironment.py
@@ -50,6 +50,12 @@ class CarBlockEnvironment(Node):
         self.COLLISION_RANGE = collision_range
         self.STEP_LENGTH = step_length
 
+        self.MAX_ACTIONS = np.asarray([3, 3.14])
+        self.MIN_ACTIONS = np.asarray([-0.5, -3.14])
+
+        self.OBSERVATION_SIZE = 8 + 10 + 2 # Car position + Lidar rays + goal position
+        self.ACTION_NUM = 2
+        
         self.step_counter = 0
 
         # Pub/Sub ----------------------------------------------------

--- a/src/environments/environments/CarGoalEnvironment.py
+++ b/src/environments/environments/CarGoalEnvironment.py
@@ -46,6 +46,11 @@ class CarGoalEnvironment(Node):
         self.MAX_STEPS = max_steps
         self.STEP_LENGTH = step_length
 
+        self.MAX_ACTIONS = np.asarray([3, 1])
+        self.MIN_ACTIONS = np.asarray([0, -1])
+
+        self.OBSERVATION_SIZE = 8 + 0 + 2 # Car position + Lidar rays + goal position
+        self.ACTION_NUM = 2
         self.step_counter = 0
 
         # Pub/Sub ----------------------------------------------------

--- a/src/environments/environments/CarWallEnvironment.py
+++ b/src/environments/environments/CarWallEnvironment.py
@@ -49,6 +49,12 @@ class CarWallEnvironment(Node):
         self.MAX_STEPS = max_steps
         self.COLLISION_RANGE = collision_range
         self.STEP_LENGTH = step_length
+        
+        self.MAX_ACTIONS = np.asarray([3, 3.14])
+        self.MIN_ACTIONS = np.asarray([-0.5, -3.14])
+
+        self.OBSERVATION_SIZE = 8 + 10 + 2 # Car position + Lidar rays + goal position
+        self.ACTION_NUM = 2
 
         self.step_counter = 0
 

--- a/src/reinforcement_learning/config/config.yaml
+++ b/src/reinforcement_learning/config/config.yaml
@@ -1,1 +1,0 @@
-mode: training

--- a/src/reinforcement_learning/config/test.yaml
+++ b/src/reinforcement_learning/config/test.yaml
@@ -1,0 +1,6 @@
+test:
+  ros__parameters:
+    environment: 'CarWall'
+    max_steps_evaluation: 1000000
+    actor_path: models/carwall_training-13-06-2023-23:24:07_0_actor.pht
+    critic_path: models/carwall_training-13-06-2023-23:24:07_0_critic.pht

--- a/src/reinforcement_learning/config/train.yaml
+++ b/src/reinforcement_learning/config/train.yaml
@@ -1,0 +1,17 @@
+train:
+  ros__parameters:
+    environment: 'CarBlock'
+    max_steps_exploration: 5000
+    max_steps_training: 1000000
+    reward_range: 1.0
+    collision_range: 2.0
+    # gamma: 0.95
+    # tau: 0.005
+    # g: 5
+    # batch_size: 32
+    # buffer_size: 1000000
+    # actor_lr: 0.0001
+    # critic_lr: 0.001
+    # max_steps: 10
+    # step_length: 0.25
+    # seed: 123

--- a/src/reinforcement_learning/launch/test.launch.py
+++ b/src/reinforcement_learning/launch/test.launch.py
@@ -1,35 +1,55 @@
 import os
 from ament_index_python import get_package_share_directory
-from launch_ros.actions import Node 
+from launch_ros.actions import Node, SetParameter
 from launch import LaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
+import yaml
+
+env_launch = {
+    'CarGoal': 'cargoal',
+    'CarWall': 'carwall',
+    'CarBlock': 'carblock'
+}
 
 def generate_launch_description():
     pkg_f1tenth_description = get_package_share_directory('f1tenth_description')
     pkg_f1tenth_bringup = get_package_share_directory('f1tenth_bringup')
     pkg_environments = get_package_share_directory('environments')
 
+    config_path = os.path.join(
+        get_package_share_directory('reinforcement_learning'),
+        'test.yaml'
+    )
+
+    config = yaml.load(open(config_path), Loader=yaml.Loader)
+    env = config['test']['ros__parameters']['environment']
+
     environment =  IncludeLaunchDescription(
         launch_description_source=PythonLaunchDescriptionSource(
-            os.path.join(pkg_environments, 'cargoal.launch.py')),
-        launch_arguments={
-            'car_name': 'f1tenth',
-        }.items() #TODO: this doesn't do anything
-    )
-    
-    f1tenth = IncludeLaunchDescription(
-        launch_description_source=PythonLaunchDescriptionSource(
-            os.path.join(pkg_f1tenth_bringup, 'f1tenth_simulation.launch.py')),
+            os.path.join(pkg_environments, f'{env_launch[env]}.launch.py')),
         launch_arguments={
             'car_name': 'f1tenth',
         }.items() #TODO: this doesn't do anything
     )
 
+    f1tenth = IncludeLaunchDescription(
+        launch_description_source=PythonLaunchDescriptionSource(
+            os.path.join(pkg_f1tenth_bringup, 'simulation_bringup.launch.py')),
+        launch_arguments={
+            'name': 'f1tenth',
+            'world': 'empty'
+        }.items()
+    )
+
     # Launch the Environment
     main = Node(
             package='reinforcement_learning',
-            executable='car_goal_testing',
+            executable='test',
+            parameters=[
+                config_path
+            ],
+            name='test',
             output='screen',
             emulate_tty=True, # Allows python print to show
     )
@@ -37,6 +57,7 @@ def generate_launch_description():
     return LaunchDescription([
         #TODO: Find a way to remove this
         SetEnvironmentVariable(name='GZ_SIM_RESOURCE_PATH', value=pkg_f1tenth_description[:-19]),
+        SetParameter(name='use_sim_time', value=True),
         environment,
         f1tenth,
         main

--- a/src/reinforcement_learning/launch/train.launch.py
+++ b/src/reinforcement_learning/launch/train.launch.py
@@ -1,44 +1,55 @@
 import os
 from ament_index_python import get_package_share_directory
-from launch_ros.actions import Node 
+from launch_ros.actions import Node, SetParameter
 from launch import LaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
+import yaml
+
+env_launch = {
+    'CarGoal': 'cargoal',
+    'CarWall': 'carwall',
+    'CarBlock': 'carblock'
+}
 
 def generate_launch_description():
     pkg_f1tenth_description = get_package_share_directory('f1tenth_description')
     pkg_f1tenth_bringup = get_package_share_directory('f1tenth_bringup')
     pkg_environments = get_package_share_directory('environments')
 
+    config_path = os.path.join(
+        get_package_share_directory('reinforcement_learning'),
+        'train.yaml'
+    )
+
+    config = yaml.load(open(config_path), Loader=yaml.Loader)
+    env = config['train']['ros__parameters']['environment']
+
     environment =  IncludeLaunchDescription(
         launch_description_source=PythonLaunchDescriptionSource(
-            os.path.join(pkg_environments, 'carwall.launch.py')),
-        launch_arguments={
-            'car_name': 'f1tenth',
-        }.items() #TODO: this doesn't do anything
-    )
-    
-    f1tenth = IncludeLaunchDescription(
-        launch_description_source=PythonLaunchDescriptionSource(
-            os.path.join(pkg_f1tenth_bringup, 'f1tenth_simulation.launch.py')),
+            os.path.join(pkg_environments, f'{env_launch[env]}.launch.py')),
         launch_arguments={
             'car_name': 'f1tenth',
         }.items() #TODO: this doesn't do anything
     )
 
-    config = os.path.join(
-        get_package_share_directory('reinforcement_learning'),
-        'car_wall.yaml'
+    f1tenth = IncludeLaunchDescription(
+        launch_description_source=PythonLaunchDescriptionSource(
+            os.path.join(pkg_f1tenth_bringup, 'simulation_bringup.launch.py')),
+        launch_arguments={
+            'name': 'f1tenth',
+            'world': 'empty'
+        }.items()
     )
 
     # Launch the Environment
     main = Node(
             package='reinforcement_learning',
-            executable='car_wall_training',
+            executable='train',
             parameters=[
-                config
+                config_path
             ],
-            name='car_wall_training',
+            name='train',
             output='screen',
             emulate_tty=True, # Allows python print to show
     )
@@ -46,6 +57,7 @@ def generate_launch_description():
     return LaunchDescription([
         #TODO: Find a way to remove this
         SetEnvironmentVariable(name='GZ_SIM_RESOURCE_PATH', value=pkg_f1tenth_description[:-19]),
+        SetParameter(name='use_sim_time', value=True),
         environment,
         f1tenth,
         main

--- a/src/reinforcement_learning/reinforcement_learning/car_block_training.py
+++ b/src/reinforcement_learning/reinforcement_learning/car_block_training.py
@@ -85,11 +85,9 @@ print(
     f'Collision Range: {COLLISION_RANGE}\n'
     f'---------------------------------------------\n'
 )
-MAX_ACTIONS = np.asarray([3, 3.14])
-MIN_ACTIONS = np.asarray([-0.5, -3.14])
 
-OBSERVATION_SIZE = 8 + 10 + 2 # Car position + Lidar rays + goal position
-ACTION_NUM = 2
+
+
 
 DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
@@ -98,15 +96,15 @@ def main():
 
     env = CarBlockEnvironment('f1tenth', step_length=STEP_LENGTH, max_steps=MAX_STEPS, reward_range=REWARD_RANGE, collision_range=COLLISION_RANGE)
     
-    actor = Actor(observation_size=OBSERVATION_SIZE, num_actions=ACTION_NUM, learning_rate=ACTOR_LR)
-    critic = Critic(observation_size=OBSERVATION_SIZE, num_actions=ACTION_NUM, learning_rate=CRITIC_LR)
+    actor = Actor(observation_size=env.OBSERVATION_SIZE, num_actions=env.ACTION_NUM, learning_rate=ACTOR_LR)
+    critic = Critic(observation_size=env.OBSERVATION_SIZE, num_actions=env.ACTION_NUM, learning_rate=CRITIC_LR)
 
     agent = TD3(
         actor_network=actor,
         critic_network=critic,
         gamma=GAMMA,
         tau=TAU,
-        action_num=ACTION_NUM,
+        action_num=env.ACTION_NUM,
         device=DEVICE
     )
 
@@ -147,11 +145,11 @@ def train(env, agent: TD3, record: Record):
 
         if total_step_counter < MAX_STEPS_EXPLORATION:
             print(f"Running Exploration Steps {total_step_counter}/{MAX_STEPS_EXPLORATION}")
-            action_env = np.asarray([random.uniform(MIN_ACTIONS[0], MAX_ACTIONS[0]), random.uniform(MIN_ACTIONS[1], MAX_ACTIONS[1])]) # action range the env uses [e.g. -2 , 2 for pendulum]
-            action = hlp.normalize(action_env, MAX_ACTIONS, MIN_ACTIONS)  # algorithm range [-1, 1]
+            action_env = np.asarray([random.uniform(env.MIN_ACTIONS[0], env.MAX_ACTIONS[0]), random.uniform(MIN_ACTIONS[1], MAX_ACTIONS[1])]) # action range the env uses [e.g. -2 , 2 for pendulum]
+            action = hlp.normalize(action_env, env.MAX_ACTIONS,env.MIN_ACTIONS)  # algorithm range [-1, 1]
         else:
             action = agent.select_action_from_policy(state) # algorithm range [-1, 1]
-            action_env = hlp.denormalize(action, MAX_ACTIONS, MIN_ACTIONS)  # mapping to env range [e.g. -2 , 2 for pendulum]
+            action_env = hlp.denormalize(action, env.MAX_ACTIONS, env.MIN_ACTIONS)  # mapping to env range [e.g. -2 , 2 for pendulum]
 
         next_state, reward, done, truncated, info = env.step(action_env)
         memory.add(state=state, action=action, reward=reward, next_state=next_state, done=done)

--- a/src/reinforcement_learning/reinforcement_learning/car_block_training.py
+++ b/src/reinforcement_learning/reinforcement_learning/car_block_training.py
@@ -145,7 +145,7 @@ def train(env, agent: TD3, record: Record):
 
         if total_step_counter < MAX_STEPS_EXPLORATION:
             print(f"Running Exploration Steps {total_step_counter}/{MAX_STEPS_EXPLORATION}")
-            action_env = np.asarray([random.uniform(env.MIN_ACTIONS[0], env.MAX_ACTIONS[0]), random.uniform(MIN_ACTIONS[1], MAX_ACTIONS[1])]) # action range the env uses [e.g. -2 , 2 for pendulum]
+            action_env = np.asarray([random.uniform(env.MIN_ACTIONS[0], env.MAX_ACTIONS[0]), random.uniform(env.MIN_ACTIONS[1], env.MAX_ACTIONS[1])]) # action range the env uses [e.g. -2 , 2 for pendulum]
             action = hlp.normalize(action_env, env.MAX_ACTIONS,env.MIN_ACTIONS)  # algorithm range [-1, 1]
         else:
             action = agent.select_action_from_policy(state) # algorithm range [-1, 1]

--- a/src/reinforcement_learning/reinforcement_learning/test.py
+++ b/src/reinforcement_learning/reinforcement_learning/test.py
@@ -1,0 +1,132 @@
+from environments.CarGoalEnvironment import CarGoalEnvironment
+from environments.CarWallEnvironment import CarWallEnvironment
+from environments.CarBlockEnvironment import CarBlockEnvironment
+import rclpy
+from ament_index_python import get_package_share_directory
+import time
+import torch
+import random
+from cares_reinforcement_learning.algorithm.policy import TD3
+from cares_reinforcement_learning.util import helpers as hlp
+from cares_reinforcement_learning.networks.TD3 import Actor, Critic
+
+import numpy as np
+
+rclpy.init()
+
+param_node = rclpy.create_node('params')
+param_node.declare_parameters(
+    '',
+    [
+        ('environment', 'CarGoal'),
+        ('max_steps_evaluation', 1_000_000),
+        ('max_steps', 100),
+        ('step_length', 0.25),
+        ('reward_range', 0.2),
+        ('collision_range', 0.2),
+        ('actor_path', ''),
+        ('critic_path', '')
+    ]
+)
+
+params = param_node.get_parameters([
+    'environment',
+    'max_steps_evaluation',
+    'max_steps',
+    'step_length',
+    'reward_range',
+    'collision_range',
+    'actor_path',
+    'critic_path',
+    ])
+
+ENVIRONMENT,\
+MAX_STEPS_EVALUATION, \
+MAX_STEPS,\
+STEP_LENGTH,\
+REWARD_RANGE,\
+COLLISION_RANGE,\
+ACTOR_PATH,\
+CRITIC_PATH = [param.value for param in params]
+
+print(
+    f'---------------------------------------------\n'
+    f'Environment: {ENVIRONMENT}\n'
+    f'Evaluation Steps: {MAX_STEPS_EVALUATION}\n'
+    f'Steps per Episode: {MAX_STEPS}\n'
+    f'Step Length: {STEP_LENGTH}\n'
+    f'Reward Range: {REWARD_RANGE}\n'
+    f'Collision Range: {COLLISION_RANGE}\n'
+    f'Critic Path: {CRITIC_PATH}\n'
+    f'Actor Path: {ACTOR_PATH}\n'
+    f'---------------------------------------------\n'
+)
+
+if ACTOR_PATH == '' or CRITIC_PATH == '':
+    raise Exception('Actor or Critic path not provided')
+
+DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+def main():
+    # Share Directories
+
+    time.sleep(3)
+
+    match(ENVIRONMENT):
+        case 'CarWall':
+            env = CarWallEnvironment('f1tenth', step_length=STEP_LENGTH, max_steps=MAX_STEPS, reward_range=REWARD_RANGE, collision_range=COLLISION_RANGE)
+        case 'CarBlock':
+            env = CarBlockEnvironment('f1tenth', step_length=STEP_LENGTH, max_steps=MAX_STEPS, reward_range=REWARD_RANGE, collision_range=COLLISION_RANGE)
+        case _:
+            env = CarGoalEnvironment('f1tenth', step_length=STEP_LENGTH, max_steps=MAX_STEPS, reward_range=REWARD_RANGE)
+    
+    actor = Actor(observation_size=env.OBSERVATION_SIZE, num_actions=env.ACTION_NUM, learning_rate=0.1)
+    critic = Critic(observation_size=env.OBSERVATION_SIZE, num_actions=env.ACTION_NUM, learning_rate=0.1)
+
+    print('Reading saved models into actor and critic')
+    actor.load_state_dict(torch.load(ACTOR_PATH))
+    critic.load_state_dict(torch.load(CRITIC_PATH))
+
+    print('Successfully Loaded models')
+    
+    agent = TD3(
+        actor_network=actor,
+        critic_network=critic,
+        gamma=0.999,
+        tau=0.002,
+        action_num=env.ACTION_NUM,
+        device=DEVICE
+    )
+
+    test(env=env, agent=agent)
+
+def test(env, agent: TD3):
+    state, _ = env.reset()    
+    episode_timesteps = 0
+    episode_reward = 0
+    episode_num = 0
+
+    print('Beginning Evaluation')
+
+    for total_step_counter in range(int(MAX_STEPS_EVALUATION)):
+        episode_timesteps += 1
+
+        action = agent.select_action_from_policy(state)
+        action_env = hlp.denormalize(action, env.MAX_ACTIONS, env.MIN_ACTIONS)
+
+        next_state, reward, done, truncated, info = env.step(action_env)
+
+        state = next_state
+        episode_reward += reward
+
+        if done or truncated:
+            print(f"Total T:{total_step_counter+1} Episode {episode_num+1} was completed with {episode_timesteps} steps taken and a Reward= {episode_reward:.3f}")
+
+            # Reset environment
+            state, _ = env.reset()
+            episode_reward    = 0
+            episode_timesteps = 0
+            episode_num += 1
+
+if __name__ == '__main__':
+    main()

--- a/src/reinforcement_learning/reinforcement_learning/train.py
+++ b/src/reinforcement_learning/reinforcement_learning/train.py
@@ -1,0 +1,195 @@
+import rclpy
+import time
+import torch
+import random
+import numpy as np
+
+from cares_reinforcement_learning.algorithm.policy import TD3
+from cares_reinforcement_learning.util import helpers as hlp
+from cares_reinforcement_learning.memory import MemoryBuffer
+from cares_reinforcement_learning.util import Record
+from cares_reinforcement_learning.networks.TD3 import Actor, Critic
+
+from environments.CarGoalEnvironment import CarGoalEnvironment
+from environments.CarWallEnvironment import CarWallEnvironment
+from environments.CarBlockEnvironment import CarBlockEnvironment
+
+rclpy.init()
+
+param_node = rclpy.create_node('params')
+param_node.declare_parameters(
+    '',
+    [
+        ('environment', 'CarGoal'),
+        ('gamma', 0.95),
+        ('tau', 0.005),
+        ('g', 10),
+        ('batch_size', 32),
+        ('buffer_size', 1_000_000),
+        ('seed', 123), #TODO: This doesn't do anything yet
+        ('actor_lr', 1e-4),
+        ('critic_lr', 1e-3),
+        ('max_steps_training', 1_000_000),
+        ('max_steps_exploration', 1_000),
+        ('max_steps', 100),
+        ('step_length', 0.25),
+        ('reward_range', 0.2),
+        ('collision_range', 0.2)
+    ]
+)
+
+params = param_node.get_parameters([
+    'environment',
+    'max_steps_training',
+    'max_steps_exploration', 
+    'gamma', 
+    'tau', 
+    'g', 
+    'batch_size', 
+    'buffer_size', 
+    'seed', 
+    'actor_lr', 
+    'critic_lr',
+    'max_steps',
+    'step_length',
+    'reward_range',
+    'collision_range'
+    ])
+
+ENVIRONMENT,\
+MAX_STEPS_TRAINING,\
+MAX_STEPS_EXPLORATION,\
+GAMMA,\
+TAU,\
+G,\
+BATCH_SIZE,\
+BUFFER_SIZE,\
+SEED,\
+ACTOR_LR,\
+CRITIC_LR,\
+MAX_STEPS,\
+STEP_LENGTH,\
+REWARD_RANGE,\
+COLLISION_RANGE = [param.value for param in params]
+
+print(
+    f'---------------------------------------------\n'
+    f'Environment: {ENVIRONMENT}\n'
+    f'Exploration Steps: {MAX_STEPS_EXPLORATION}\n'
+    f'Training Steps: {MAX_STEPS_TRAINING}\n'
+    f'Gamma: {GAMMA}\n'
+    f'Tau: {TAU}\n'
+    f'G: {G}\n'
+    f'Batch Size: {BATCH_SIZE}\n'
+    f'Buffer Size: {BUFFER_SIZE}\n'
+    f'Seed: {SEED}\n'
+    f'Actor LR: {ACTOR_LR}\n'
+    f'Critic LR: {CRITIC_LR}\n'
+    f'Steps per Episode: {MAX_STEPS}\n'
+    f'Step Length: {STEP_LENGTH}\n'
+    f'Reward Range: {REWARD_RANGE}\n'
+    f'Collision Range: {COLLISION_RANGE}\n'
+    f'---------------------------------------------\n'
+)
+
+DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+def main():
+    time.sleep(3)
+
+    match(ENVIRONMENT):
+        case 'CarWall':
+            env = CarWallEnvironment('f1tenth', step_length=STEP_LENGTH, max_steps=MAX_STEPS, reward_range=REWARD_RANGE, collision_range=COLLISION_RANGE)
+        case 'CarBlock':
+            env = CarBlockEnvironment('f1tenth', step_length=STEP_LENGTH, max_steps=MAX_STEPS, reward_range=REWARD_RANGE, collision_range=COLLISION_RANGE)
+        case _:
+            env = CarGoalEnvironment('f1tenth', step_length=STEP_LENGTH, max_steps=MAX_STEPS, reward_range=REWARD_RANGE)
+    
+    actor = Actor(observation_size=env.OBSERVATION_SIZE, num_actions=env.ACTION_NUM, learning_rate=ACTOR_LR)
+    critic = Critic(observation_size=env.OBSERVATION_SIZE, num_actions=env.ACTION_NUM, learning_rate=CRITIC_LR)
+
+    agent = TD3(
+        actor_network=actor,
+        critic_network=critic,
+        gamma=GAMMA,
+        tau=TAU,
+        action_num=env.ACTION_NUM,
+        device=DEVICE
+    )
+
+    networks = {'actor': actor, 'critic': critic}
+    config = {
+        'max_steps_training':MAX_STEPS_TRAINING,
+        'max_steps_exploration': MAX_STEPS_EXPLORATION, 
+        'gamma': GAMMA, 
+        'tau': TAU, 
+        'g': G, 
+        'batch_size': BATCH_SIZE, 
+        'buffer_size': BUFFER_SIZE, 
+        'seed': SEED, 
+        'actor_lr': ACTOR_LR, 
+        'critic_lr': CRITIC_LR,
+        'max_steps': MAX_STEPS,
+        'step_length': STEP_LENGTH,
+    }
+    record = Record(networks=networks, checkpoint_freq=MAX_STEPS_TRAINING / 10, config=config)
+
+    train(env=env, agent=agent, record=record)
+
+def train(env, agent: TD3, record: Record):
+    
+    memory = MemoryBuffer()
+
+    episode_timesteps = 0
+    episode_reward    = 0
+    episode_num       = 0
+
+    state, _ = env.reset()
+
+    historical_reward = {"step": [], "episode_reward": []}    
+
+
+    for total_step_counter in range(int(MAX_STEPS_TRAINING)):
+        episode_timesteps += 1
+
+        if total_step_counter < MAX_STEPS_EXPLORATION:
+            print(f"Running Exploration Steps {total_step_counter}/{MAX_STEPS_EXPLORATION}")
+            action_env = np.asarray([random.uniform(env.MIN_ACTIONS[0], env.MAX_ACTIONS[0]), random.uniform(env.MIN_ACTIONS[1], env.MAX_ACTIONS[1])]) # action range the env uses [e.g. -2 , 2 for pendulum]
+            action = hlp.normalize(action_env, env.MAX_ACTIONS, env.MIN_ACTIONS)  # algorithm range [-1, 1]
+        else:
+            action = agent.select_action_from_policy(state) # algorithm range [-1, 1]
+            action_env = hlp.denormalize(action, env.MAX_ACTIONS, env.MIN_ACTIONS)  # mapping to env range [e.g. -2 , 2 for pendulum]
+
+        next_state, reward, done, truncated, info = env.step(action_env)
+        memory.add(state=state, action=action, reward=reward, next_state=next_state, done=done)
+
+        state = next_state
+        episode_reward += reward
+
+        if total_step_counter >= MAX_STEPS_EXPLORATION:
+                for _ in range(G):
+                    experiences = memory.sample(BATCH_SIZE)
+                    experiences = (experiences['state'], experiences['action'], experiences['reward'], experiences['next_state'], experiences['done'])
+                    agent.train_policy(experiences)
+
+        record.log(
+            out=done or truncated,
+            Step=total_step_counter,
+            Episode=episode_num,
+            Step_Reward=reward,
+            Episode_Reward=episode_reward if (done or truncated) else None,
+        )
+
+        if done or truncated:
+
+            historical_reward["step"].append(total_step_counter)
+            historical_reward["episode_reward"].append(episode_reward)
+
+            # Reset environment
+            state, _ = env.reset()
+            episode_reward    = 0
+            episode_timesteps = 0
+            episode_num += 1
+
+if __name__ == '__main__':
+    main()

--- a/src/reinforcement_learning/setup.py
+++ b/src/reinforcement_learning/setup.py
@@ -30,6 +30,7 @@ setup(
             'car_wall_testing = reinforcement_learning.car_wall_testing:main',
             'car_block_training = reinforcement_learning.car_block_training:main',
             'sanity_check = reinforcement_learning.sanity_check:main',
+            'train = reinforcement_learning.train:main'
             
         ],
     },

--- a/src/reinforcement_learning/setup.py
+++ b/src/reinforcement_learning/setup.py
@@ -30,7 +30,8 @@ setup(
             'car_wall_testing = reinforcement_learning.car_wall_testing:main',
             'car_block_training = reinforcement_learning.car_block_training:main',
             'sanity_check = reinforcement_learning.sanity_check:main',
-            'train = reinforcement_learning.train:main'
+            'train = reinforcement_learning.train:main',
+            'test = reinforcement_learning.test:main'
             
         ],
     },


### PR DESCRIPTION
Training and Testing loops are the same across the different environments. Now that #47 has moved environment specific information (OBSERVATION_SIZE, ACTION_NUM, MAX_ACTIONS) inside the environment class, we can write one training loops and switch out the environments.

This PR introduces the `train.py` and `test.py` scripts. To run an experiment, we alter the `train.yaml` then run the `train.launch.py`. If we want to test our models on an environment, we alter the `test.yaml` and run the `test.launch.py`. This is much cleaner.

Eventually we should remove all the `car_wall_training`,  `car_wall_testing` etc. (Environment specific training loops) in future, but I have for the moment to allow a gradual transition to the new set up.