### PR TITLE
Import model back

### DIFF
--- a/retrain.sh
+++ b/retrain.sh
@@ -9,8 +9,10 @@ trap cleanup SIGINT SIGTERM
 
 # Time limit for training
 if [ -z "$1" ]; then
-  echo "Please enter the time limit for training, usage: ./retrain.sh <time_limit> [<partition_number>]"
-  echo "Eg: 10s, 6h -> usage: ./retrain.sh 10s"
+  echo "Please enter the time limit for training"
+  echo "Usage: ./retrain.sh <time_limit> [<partition_number>]"
+  echo "Eg: 10s, 6h"
+  echo "Usage: ./retrain.sh 10s"
   exit 1
 fi
 
@@ -29,12 +31,20 @@ while true; do
 	timeout "$1" gz sim -g &
 	timeout "$1" ros2 launch reinforcement_learning train.launch.py
 
+  # Get the latest folder in rl_logs
+	latest_folder=$(ls -lt ./rl_logs | grep '^d' | head -n 1 | awk '{print $NF}')
+
 	# Set the new paths for actor_path and critic_path
-	new_actor_path=""
-	new_critic_path=""
+	new_actor_path="rl_logs/$latest_folder/models/actor_checkpoint.pht"
+	new_critic_path="rl_logs/$latest_folder/models/critic_checkpoint.pht"
+
+  # Check if the new paths exist
+	if [ ! -e "$new_actor_path" ] || [ ! -e "$new_critic_path" ]; then
+    echo "Error: $new_actor_path or $new_critic_path does not exist"
+    exit 1
+  fi
 
 	# Use sed to update the actor_path and critic_path in the YAML file
 	sed -i "s#actor_path: '.*'#actor_path: '$new_actor_path'#g" src/reinforcement_learning/config/train.yaml
 	sed -i "s#critic_path: '.*'#critic_path: '$new_critic_path'#g" src/reinforcement_learning/config/train.yaml
 done
-

--- a/retrain.sh
+++ b/retrain.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Ctrl + C to exit the program
+function cleanup() {
+  exit 1
+}
+
+trap cleanup SIGINT SIGTERM
+
+# Time limit for training
+if [ -z "$1" ]; then
+  echo "Please enter the time limit for training, usage: ./retrain.sh <time_limit> [<partition_number>]"
+  echo "Eg: 10s, 6h -> usage: ./retrain.sh 10s"
+  exit 1
+fi
+
+# Set the partition number
+if [ -n "$2" ]; then
+	export GZ_PARTITION="$2"
+else
+	export GZ_PARTITION=150
+fi
+
+. install/setup.bash
+
+# Rerun every $1 time
+while true; do
+	colcon build
+	timeout "$1" gz sim -g &
+	timeout "$1" ros2 launch reinforcement_learning train.launch.py
+
+	# Set the new paths for actor_path and critic_path
+	new_actor_path=""
+	new_critic_path=""
+
+	# Use sed to update the actor_path and critic_path in the YAML file
+	sed -i "s#actor_path: '.*'#actor_path: '$new_actor_path'#g" src/reinforcement_learning/config/train.yaml
+	sed -i "s#critic_path: '.*'#critic_path: '$new_critic_path'#g" src/reinforcement_learning/config/train.yaml
+done
+

--- a/src/reinforcement_learning/config/train.yaml
+++ b/src/reinforcement_learning/config/train.yaml
@@ -6,8 +6,8 @@ train:
     max_steps_training: 1000000
     reward_range: 1.0
     collision_range: 0.2
-    actor_path: rl_logs/23_07_17_01:50:30/models/actor_checkpoint.pht
-    critic_path: rl_logs/23_07_17_01:50:30/models/critic_checkpoint.pht
+    actor_path: 'rl_logs/23_07_17_01:50:30/models/actor_checkpoint.pht'
+    critic_path: 'rl_logs/23_07_17_01:50:30/models/critic_checkpoint.pht'
     # gamma: 0.95
     # tau: 0.005
     # g: 5

--- a/src/reinforcement_learning/config/train.yaml
+++ b/src/reinforcement_learning/config/train.yaml
@@ -1,11 +1,13 @@
 train:
   ros__parameters:
     environment: 'CarTrack' # CarGoal, CarWall, CarBlock, CarTrack
-    track: 'track_1' # track_1, track_2, track_3 -> only applies for CarTrack
     max_steps_exploration: 5000
+    track: 'track_2' # track_1, track_2, track_3 -> only applies for CarTrack
     max_steps_training: 1000000
     reward_range: 1.0
     collision_range: 0.2
+    actor_path: rl_logs/23_07_17_01:50:30/models/actor_checkpoint.pht
+    critic_path: rl_logs/23_07_17_01:50:30/models/critic_checkpoint.pht
     # gamma: 0.95
     # tau: 0.005
     # g: 5

--- a/src/reinforcement_learning/reinforcement_learning/train.py
+++ b/src/reinforcement_learning/reinforcement_learning/train.py
@@ -41,7 +41,9 @@ def main():
     MAX_STEPS, \
     STEP_LENGTH, \
     REWARD_RANGE, \
-    COLLISION_RANGE = [param.value for param in params]
+    COLLISION_RANGE, \
+    ACTOR_PATH, \
+    CRITIC_PATH = [param.value for param in params]
 
     print(
         f'---------------------------------------------\n'
@@ -60,6 +62,8 @@ def main():
         f'Step Length: {STEP_LENGTH}\n'
         f'Reward Range: {REWARD_RANGE}\n'
         f'Collision Range: {COLLISION_RANGE}\n'
+        f'Critic Path: {CRITIC_PATH}\n'
+        f'Actor Path: {ACTOR_PATH}\n'
         f'---------------------------------------------\n'
     )
 
@@ -78,6 +82,12 @@ def main():
 
     actor = Actor(observation_size=env.OBSERVATION_SIZE, num_actions=env.ACTION_NUM, learning_rate=ACTOR_LR)
     critic = Critic(observation_size=env.OBSERVATION_SIZE, num_actions=env.ACTION_NUM, learning_rate=CRITIC_LR)
+
+    if ACTOR_PATH != '' and CRITIC_PATH != '':
+        print('Reading saved models into actor and critic')
+        actor.load_state_dict(torch.load(ACTOR_PATH))
+        critic.load_state_dict(torch.load(CRITIC_PATH))
+        print('Successfully Loaded models')
 
     agent = TD3(
         actor_network=actor,
@@ -192,7 +202,9 @@ def get_params():
             ('max_steps', 100),
             ('step_length', 0.25),
             ('reward_range', 0.2),
-            ('collision_range', 0.2)
+            ('collision_range', 0.2),
+            ('actor_path', ''),
+            ('critic_path', '')
         ]
     )
 
@@ -212,7 +224,9 @@ def get_params():
         'max_steps',
         'step_length',
         'reward_range',
-        'collision_range'
+        'collision_range',
+        'actor_path',
+        'critic_path',
     ])
 
 

--- a/src/reinforcement_learning/reinforcement_learning/train.py
+++ b/src/reinforcement_learning/reinforcement_learning/train.py
@@ -45,6 +45,9 @@ def main():
     ACTOR_PATH, \
     CRITIC_PATH = [param.value for param in params]
 
+    if ACTOR_PATH != '' and CRITIC_PATH != '':
+        MAX_STEPS_EXPLORATION = 0
+
     print(
         f'---------------------------------------------\n'
         f'Environment: {ENVIRONMENT}\n'


### PR DESCRIPTION
By Nick & Bowen

# PLEASE READ
# Change:
- In train.yaml, if actor_path and critic_path are specified, we can continue training with previous trained model.
- Also if they are specified, the exploration steps is 0. Because no point to explore when we have the trained model.
- Added a bash script that restart the training every $1 time ($1 is the input param). After each restart, it will get the latest stored/modified model and then use it to continue training it.

## Note:
- To restart the training every $1 time, you **HAVE TO** run the training via. `retrain.sh`.
- If either actor_path and critic_path is not specified, then it will run the training like before.