### PR TITLE
Uneven median lidar processing

### DIFF
--- a/src/environments/environments/util.py
+++ b/src/environments/environments/util.py
@@ -123,6 +123,28 @@ def avg_lidar(lidar: LaserScan, num_points: int):
         
         return new_range
 
+def uneven_median_lidar(lidar: LaserScan, num_points: int):
+        ranges = lidar.ranges
+        ranges = np.nan_to_num(ranges, nan=float(10), posinf=float(10), neginf=float(10))
+        new_range = []
+        
+        window_size = [121, 70, 60 ,50, 40, 40, 50, 60, 70, 122]
+        
+        if len(ranges) != sum(window_size):
+            raise Exception("Lidar length and window size do not match")
+        
+        if len(window_size) != num_points:
+            raise Exception("Window size length and num_points do not match")
+        
+        start = 0
+        for window in window_size:
+            end = start + window
+            window_ranges = ranges[start:end]
+            new_range.append(float(np.median(window_ranges)))
+            start = end
+            
+        return new_range
+
 def avg_lidar_w_consensus(lidar:LaserScan, num_points:int):
     '''For each 'sector', count non hitting rays, if non hitting rays >= 50% consider entire sector non-hitting. Otherwise use avg of hitting rays.'''
     ranges = lidar.ranges


### PR DESCRIPTION
Used varying window sizes for every processed points to have a stronger emphasis on further points. Median filter is used to negate the effect of NaN values. This processing method showed positive improvements in testing.